### PR TITLE
add fields, and fix bug for German dictionary

### DIFF
--- a/designer/main.ui
+++ b/designer/main.ui
@@ -91,7 +91,59 @@
      <item row="6" column="1">
       <widget class="QComboBox" name="POSFieldComboBox"/>
      </item>
+     <item row="7" column="0">
+      <widget class="QLabel" name="label_6">
+       <property name="text">
+        <string>&amp;IPA</string>
+       </property>
+       <property name="buddy">
+        <cstring>IPAFieldComboBox</cstring>
+       </property>
+      </widget>
+     </item>
      <item row="7" column="1">
+      <widget class="QComboBox" name="IPAFieldComboBox"/>
+     </item>
+     <item row="8" column="0">
+      <widget class="QLabel" name="label_7">
+       <property name="text">
+        <string>&amp;Audio</string>
+       </property>
+       <property name="buddy">
+        <cstring>audioFieldComboBox</cstring>
+       </property>
+      </widget>
+     </item>
+     <item row="8" column="1">
+      <widget class="QComboBox" name="audioFieldComboBox"/>
+     </item>
+     <item row="9" column="0">
+      <widget class="QLabel" name="label_8">
+       <property name="text">
+        <string>&amp;Etymology</string>
+       </property>
+       <property name="buddy">
+        <cstring>etymologyFieldComboBox</cstring>
+       </property>
+      </widget>
+     </item>
+     <item row="9" column="1">
+      <widget class="QComboBox" name="etymologyFieldComboBox"/>
+     </item>
+     <item row="10" column="0">
+      <widget class="QLabel" name="label_9">
+       <property name="text">
+        <string>&amp;Declension</string>
+       </property>
+       <property name="buddy">
+        <cstring>declensionFieldComboBox</cstring>
+       </property>
+      </widget>
+     </item>
+     <item row="10" column="1">
+      <widget class="QComboBox" name="declensionFieldComboBox"/>
+     </item>
+     <item row="11" column="1">
       <widget class="QPushButton" name="addButton">
        <property name="text">
         <string>Add</string>
@@ -99,7 +151,7 @@
       </widget>
      </item>
      <item row="1" column="0">
-      <widget class="QLabel" name="label_6">
+      <widget class="QLabel" name="label_10">
        <property name="text">
         <string>&amp;Dictionary</string>
        </property>
@@ -119,6 +171,11 @@
   <tabstop>wordFieldComboBox</tabstop>
   <tabstop>definitionFieldComboBox</tabstop>
   <tabstop>exampleFieldComboBox</tabstop>
+  <tabstop>POSFieldComboBox</tabstop>
+  <tabstop>IPAFieldComboBox</tabstop>
+  <tabstop>audioFieldComboBox</tabstop>
+  <tabstop>etymologyFieldComboBox</tabstop>
+  <tabstop>declensionFieldComboBox</tabstop>
   <tabstop>addButton</tabstop>
  </tabstops>
  <resources/>

--- a/src/config.json
+++ b/src/config.json
@@ -6,5 +6,9 @@
     "definition_field": "",
     "example_field": "",
     "gender_field": "",
-    "part_of_speech_field": ""
+    "part_of_speech_field": "",
+    "ipa_field": "",
+    "audio_field": "",
+    "etymology_field": "",
+    "declension_field": ""
 }

--- a/src/fetcher.py
+++ b/src/fetcher.py
@@ -117,7 +117,7 @@ class WiktionaryFetcher:
                 return sound["ipa"]
         return ""
 
-    def get_audio(self, word: str) -> str:
+    def get_audio_url(self, word: str) -> str:
         data = self.get_word_json(word)
         sounds = data.get("sounds", [])
         for sound in sounds:

--- a/src/gui/main.py
+++ b/src/gui/main.py
@@ -51,6 +51,10 @@ class WiktionaryFetcherDialog(QDialog):
             self.form.exampleFieldComboBox,
             self.form.genderFieldComboBox,
             self.form.POSFieldComboBox,
+            self.form.IPAFieldComboBox,
+            self.form.audioFieldComboBox,
+            self.form.etymologyFieldComboBox,
+            self.form.declensionFieldComboBox,
         ]
         self.setWindowTitle(consts.ADDON_NAME)
         self.form.icon.setPixmap(
@@ -98,6 +102,10 @@ class WiktionaryFetcherDialog(QDialog):
         "example_field",
         "gender_field",
         "part_of_speech_field",
+        "ipa_field",
+        "audio_field",
+        "etymology_field",
+        "declension_field",
     )
 
     def set_last_used_settings(self) -> None:
@@ -149,11 +157,19 @@ class WiktionaryFetcherDialog(QDialog):
         example_field_i = self.form.exampleFieldComboBox.currentIndex()
         gender_field_i = self.form.genderFieldComboBox.currentIndex()
         pos_field_i = self.form.POSFieldComboBox.currentIndex()
+        ipa_field_i = self.form.IPAFieldComboBox.currentIndex()
+        audio_field_i = self.form.audioFieldComboBox.currentIndex()
+        etymology_field_i = self.form.etymologyFieldComboBox.currentIndex()
+        declension_field_i = self.form.declensionFieldComboBox.currentIndex()
         field_tuples = (
             (definition_field_i, self._get_definitions),
             (example_field_i, self._get_examples),
             (gender_field_i, self._get_gender),
             (pos_field_i, self._get_part_of_speech),
+            (ipa_field_i, self._get_ipa),
+            (audio_field_i, self._get_audio),
+            (etymology_field_i, self._get_etymology),
+            (declension_field_i, self._get_declension),
         )
 
         def on_success(ret: Any) -> None:
@@ -254,3 +270,24 @@ class WiktionaryFetcherDialog(QDialog):
     def _get_part_of_speech(self, word: str) -> str:
         downloader = cast(WiktionaryFetcher, self.downloader)
         return downloader.get_part_of_speech(word)
+
+    def _get_ipa(self, word: str) -> str:
+        downloader = cast(WiktionaryFetcher, self.downloader)
+        return downloader.get_ipa(word)
+
+    def _get_audio(self, word: str) -> str:
+        downloader = cast(WiktionaryFetcher, self.downloader)
+        return downloader.get_audio(word)
+
+    def _get_etymology(self, word: str) -> str:
+        downloader = cast(WiktionaryFetcher, self.downloader)
+        return downloader.get_etymology(word)
+
+    def _get_declension(self, word: str) -> str:
+        downloader = cast(WiktionaryFetcher, self.downloader)
+        declensions = downloader.get_declension(word)
+        formatted = "<ul>"
+        for key, value in declensions.items():
+            formatted += f"  <li>{key}: {', '.join(value)}</li>\r\n"
+        formatted += "</ul>"
+        return formatted

--- a/src/gui/main.py
+++ b/src/gui/main.py
@@ -294,6 +294,6 @@ class WiktionaryFetcherDialog(QDialog):
             return ""
         formatted = "<ul>"
         for key, value in declensions.items():
-            formatted += f"  <li>{key}: {', '.join(value)}</li>\r\n"
+            formatted += f"<li>{key}: {', '.join(value)}</li>"
         formatted += "</ul>"
         return formatted

--- a/src/gui/main.py
+++ b/src/gui/main.py
@@ -244,6 +244,8 @@ class WiktionaryFetcherDialog(QDialog):
     def _get_definitions(self, word: str) -> str:
         downloader = cast(WiktionaryFetcher, self.downloader)
         defs = downloader.get_senses(word)
+        if len(defs) == 0:
+            return ""
         if len(defs) == 1:
             return defs[0]
         formatted = "<ul>"
@@ -255,6 +257,8 @@ class WiktionaryFetcherDialog(QDialog):
     def _get_examples(self, word: str) -> str:
         downloader = cast(WiktionaryFetcher, self.downloader)
         examples = downloader.get_examples(word)
+        if len(examples) == 0:
+            return ""
         if len(examples) == 1:
             return examples[0]
         formatted = "<ul>"
@@ -286,6 +290,8 @@ class WiktionaryFetcherDialog(QDialog):
     def _get_declension(self, word: str) -> str:
         downloader = cast(WiktionaryFetcher, self.downloader)
         declensions = downloader.get_declension(word)
+        if len(declensions) == 0:
+            return ""
         formatted = "<ul>"
         for key, value in declensions.items():
             formatted += f"  <li>{key}: {', '.join(value)}</li>\r\n"


### PR DESCRIPTION
- I added several new fields 'IPA', 'Audio', 'Etymology' & Declension', because I personally found them useful, and I think other users may want them too.
- I found that in kaikki German Dictionary, the key for gender is different ('senses' instead of 'forms'), so I edited that code such that it will use 'senses' if it is a German Dictionary.
- I've tried the code on German dictionary only, not sure if it will work on other languages.