### PR TITLE
<fix> use glosses if raw_glosses doesn't exist

### DIFF
--- a/src/fetcher.py
+++ b/src/fetcher.py
@@ -71,7 +71,7 @@ class WiktionaryFetcher:
 
     def get_senses(self, word: str) -> list[str]:
         data = self.get_word_json(word)
-        return ["\n".join(d.get("raw_glosses", [])) for d in data.get("senses", [])]
+        return ["\n".join(d.get("raw_glosses", d.get("glosses", []))) for d in data.get("senses", [])]
 
     def get_examples(self, word: str) -> list[str]:
         data = self.get_word_json(word)


### PR DESCRIPTION
I found that some entities in the latest German dictionary on kaikkai.org doesn't have the field `raw_glosses` (e.g., [haltbar - German](https://kaikki.org/dictionary/German/meaning/h/ha/haltbar.html)). It seems that now `raw_glosses` exists only if the sense contains `tags` (those words in brackets).
To make sure we can get the definition, it's better to obtain `glosses` when `raw_glosses` is absent.